### PR TITLE
Increase errno dependency lower bound to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "loopdev"
 direct_io = []
 
 [dependencies]
-errno = "0.2.8"
+errno = "0.3.0"
 libc = "0.2.105"
 
 [build-dependencies]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/677