### PR TITLE
Add function path_result which returns Result instead of Option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: loopdev-3 ci
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,13 @@ impl LoopDevice {
         std::fs::read_link(&p).ok()
     }
 
+    // Get the path of the loop device preserving the error stack.
+    pub fn path_result(&self) -> Result<PathBuf, io::Error> {
+        let mut p = PathBuf::from("/proc/self/fd");
+        p.push(self.device.as_raw_fd().to_string());
+        std::fs::read_link(&p)
+    }
+
     /// Get the device major number
     ///
     /// # Errors


### PR DESCRIPTION
This preserves the error stack.
