### PR TITLE
Add functions to get original file name and loop device info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use crate::bindings::{
     loop_info64, LOOP_CLR_FD, LOOP_CTL_ADD, LOOP_CTL_GET_FREE, LOOP_SET_CAPACITY, LOOP_SET_FD,
     LOOP_SET_STATUS64, LO_FLAGS_AUTOCLEAR, LO_FLAGS_PARTSCAN, LO_FLAGS_READ_ONLY,
 };
+use bindings::LOOP_GET_STATUS64;
 #[cfg(feature = "direct_io")]
 use bindings::LOOP_SET_DIRECT_IO;
 use libc::{c_int, ioctl};
@@ -52,12 +53,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use loname::Name;
+
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
 #[allow(non_snake_case)]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
+
+mod loname;
 
 #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 type IoctlRequest = libc::c_ulong;
@@ -236,20 +241,22 @@ impl LoopDevice {
     /// for further details) or when calling the ioctl to attach the backing
     /// file to the device.
     pub fn attach_file<P: AsRef<Path>>(&self, backing_file: P) -> io::Result<()> {
-        let info = loop_info64 {
-            ..Default::default()
-        };
-
-        Self::attach_with_loop_info(self, backing_file, info)
+        Self::attach_with_loop_info(self, backing_file, loop_info64::default())
     }
 
     /// Attach the loop device to a file with `loop_info64`.
     fn attach_with_loop_info(
         &self, // TODO should be mut? - but changing it is a breaking change
         backing_file: impl AsRef<Path>,
-        info: loop_info64,
+        mut info: loop_info64,
     ) -> io::Result<()> {
         let write_access = (info.lo_flags & LO_FLAGS_READ_ONLY) == 0;
+
+        // store backing file name in the info
+        let name = loname::Name::from_path(&backing_file).unwrap_or(Name::default());
+        info.lo_file_name = name.0.clone();
+        info.lo_crypt_name = name.0;
+
         let bf = OpenOptions::new()
             .read(true)
             .write(write_access)
@@ -290,6 +297,23 @@ impl LoopDevice {
         let mut p = PathBuf::from("/proc/self/fd");
         p.push(self.device.as_raw_fd().to_string());
         std::fs::read_link(&p).ok()
+    }
+
+    /// Try to obtain the original file path used on mapping
+    /// The method ignores ioctl errors
+    ///
+    /// # Return
+    /// The path expected to be stored in the loop_info64.
+    /// If it's not there, method returns None, otherwise - the string stored
+    pub fn original_path(&self) -> Option<PathBuf> {
+        self.info().ok().and_then(|info| {
+            let name = Name(info.lo_file_name).to_string();
+            if name.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(name))
+            }
+        })
     }
 
     /// Get the device major number
@@ -368,6 +392,21 @@ impl LoopDevice {
             )
         })?;
         Ok(())
+    }
+
+    /// Obtain loop_info64 struct for the loop device
+    /// # Return
+    /// Ok(loop_info64) - successfully obtained info
+    /// Err(std::io::Error) - error from ioctl
+    pub fn info(&self) -> Result<loop_info64, std::io::Error> {
+        let empty_info = Box::new(loop_info64::default());
+        let fd = self.device.as_raw_fd();
+
+        unsafe {
+            let ptr = Box::into_raw(empty_info);
+            let ret_code = libc::ioctl(fd.as_raw_fd(), LOOP_GET_STATUS64 as IoctlRequest, ptr);
+            ioctl_to_error(ret_code).map(|_| *Box::from_raw(ptr))
+        }
     }
 
     /// Enable or disable direct I/O for the backing file.

--- a/src/loname.rs
+++ b/src/loname.rs
@@ -1,0 +1,86 @@
+//! Configuration structures for loop device
+
+use std::path::Path;
+
+use crate::bindings::LO_NAME_SIZE;
+
+/// Loop device name
+#[repr(C)]
+#[derive(Debug)]
+pub struct Name(pub [libc::__u8; LO_NAME_SIZE as usize]);
+
+/// Allow to construct the config easily
+impl Default for Name {
+    fn default() -> Self {
+        Self([0; LO_NAME_SIZE as usize])
+    }
+}
+
+/// Conversions simplifiers
+impl Name {
+    pub fn from_path<Y: AsRef<Path>>(path: Y) -> Result<Self, String> {
+        let s = path.as_ref().as_os_str().as_encoded_bytes();
+        if s.len() > LO_NAME_SIZE as usize {
+            return Err(format!(
+                "too many bytes in the provided loop dev source file path: {}, max {LO_NAME_SIZE}",
+                s.len()
+            ));
+        }
+        let mut data: [u8; 64] = [0; LO_NAME_SIZE as usize];
+        for (idx, byte) in s.into_iter().enumerate() {
+            data[idx] = *byte;
+        }
+        Ok(Self(data))
+    }
+}
+impl ToString for Name {
+    fn to_string(&self) -> String {
+        self.0
+            .iter()
+            .filter_map(|ch| {
+                let ch: char = *ch as char;
+                if ch == '\0' {
+                    None
+                } else {
+                    Some(ch)
+                }
+            })
+            .collect::<String>()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use super::Name;
+
+    #[test]
+    fn test_name_empty() {
+        let name = Name::default();
+        for num in name.0 {
+            assert_eq!(0, num);
+        }
+    }
+
+    #[test]
+    fn test_name_from_to() {
+        let path_string = "/a/b/some-file/cool name";
+        let path = PathBuf::from(&path_string);
+        let name = Name::from_path(path);
+
+        assert_eq!(path_string, name.unwrap().to_string());
+    }
+
+    #[test]
+    fn test_name_too_long() {
+        let path_string = "/too-long/too-long/too-long/too-long/too-long/too-long/too-long--";
+        let path = PathBuf::from(&path_string);
+        let name = Name::from_path(path);
+
+        assert_eq!(
+            "too many bytes in the provided loop dev source file path: 65, max 64",
+            name.unwrap_err()
+        )
+    }
+}


### PR DESCRIPTION
It could be useful to be able to get original file name and info of a loop device in case the original LoopDevice isn't available for any reason.

I have some more changes in mind like listing devices, applying `LoopConfig` instead of calling attach, etc

# Testing
All tests worked but `add_a_loop_device`.
I don't think it's related to the change.